### PR TITLE
feat: add instrumenter options in confg

### DIFF
--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -7,6 +7,10 @@ var createCoveragePreprocessor = function(logger, basePath, reporters, coverageR
   var log = logger.create('preprocessor.coverage');
   var instrumenterOverrides = (coverageReporter && coverageReporter.instrumenter) || {};
   var instrumenters = {istanbul: istanbul, ibrik: ibrik, ismailia: ismailia};
+  var instrumentersOptions = Object.keys(instrumenters).reduce(function getInstumenterOptions(memo, instrumenterName){
+    memo[instrumenterName] = (coverageReporter && coverageReporter.instrumenterOptions && coverageReporter.instrumenterOptions[instrumenterName]) || {};
+    return memo;
+  }, {});
 
   // if coverage reporter is not used, do not preprocess the files
   if (reporters.indexOf('coverage') === -1) {
@@ -45,7 +49,7 @@ var createCoveragePreprocessor = function(logger, basePath, reporters, coverageR
       }
     }
 
-    var instrumenter = new instrumenters[instrumenterLiteral].Instrumenter();
+    var instrumenter = new instrumenters[instrumenterLiteral].Instrumenter(instrumentersOptions[instrumenterLiteral]);
 
     instrumenter.instrument(content, jsPath, function(err, instrumentedCode) {
       if (err) {


### PR DESCRIPTION
Following https://github.com/Spote/ismailia/pull/2

Here is a path to make it work with this karma-coverage

still with this syntax

```js
coverageReporter: {
  instrumenter: {
    '**/*.js': 'ismailia'
  },
  instrumenterOptions: {
    ismailia: {
      traceur: {
        options: {
          modules: 'instantiate'
        }
      }
    }
  }
}
```