### PR TITLE
merge intrumenter changes from douglasduteil/karma-coverage back to Spote/karma-coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,21 +166,23 @@ coverageReporter: {
 ```
 
 #### instrumenter
-Karma-coverage infers the instrumenter regarding of the file extension.
-  The .coffee files are by default covered using
-  [Ibrik](https://github.com/Constellation/ibrik) (an
-  [Istanbul](https://github.com/gotwarlost/istanbul) analog for
-  CoffeeScript files). It is possible to override this behavior and point out an
+Karma-coverage can infers the instrumenter regarding of the file extension.
+  It is possible to override this behavior and point out an
   instrumenter for the files matching a specific pattern.
   To do so, you need to declare an object under with the keys representing the
   pattern to match, and the instrumenter to apply. The matching will be done
   using [minimatch](https://github.com/isaacs/minimatch).
   If two patterns match, the last one will take the precedence.
 
+For example you can use [Ibrik](https://github.com/Constellation/ibrik) (an
+  [Istanbul](https://github.com/gotwarlost/istanbul) analog for
+  CoffeeScript files) with:
+
 ```javascript
 coverageReporter: {
+  instrumenters: { ibrik : require('ibrik') }
   instrumenter: {
-    '**/*.coffee': 'istanbul' // Force the use of the Istanbul instrumenter to cover CoffeeScript files
+    '**/*.coffee': 'ibrik'
   },
   // ...
 }

--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -1,12 +1,11 @@
 var istanbul  = require('istanbul'),
-    ibrik     = require('ibrik'),
-    ismailia  = require('ismailia'),
-    minimatch = require('minimatch');
+    minimatch = require('minimatch'),
+    extend = require('util')._extend;
 
 var createCoveragePreprocessor = function(logger, basePath, reporters, coverageReporter) {
   var log = logger.create('preprocessor.coverage');
   var instrumenterOverrides = (coverageReporter && coverageReporter.instrumenter) || {};
-  var instrumenters = {istanbul: istanbul, ibrik: ibrik, ismailia: ismailia};
+  var instrumenters = extend({istanbul: istanbul}, (coverageReporter && coverageReporter.instrumenters));
   var instrumentersOptions = Object.keys(instrumenters).reduce(function getInstumenterOptions(memo, instrumenterName){
     memo[instrumenterName] = (coverageReporter && coverageReporter.instrumenterOptions && coverageReporter.instrumenterOptions[instrumenterName]) || {};
     return memo;
@@ -24,7 +23,7 @@ var createCoveragePreprocessor = function(logger, basePath, reporters, coverageR
     var literal;
     for (var pattern in instrumenterOverrides) {
       literal = String(instrumenterOverrides[pattern]).toLowerCase();
-      if (literal !== 'istanbul' && literal !== 'ibrik' && literal !== 'ismailia') {
+      if (Object.keys(instrumenters).indexOf(literal) < 0) {
         log.error('Unknown instrumenter: %s', literal);
         return false;
       }
@@ -41,7 +40,8 @@ var createCoveragePreprocessor = function(logger, basePath, reporters, coverageR
     log.debug('Processing "%s".', file.originalPath);
 
     var jsPath = file.originalPath.replace(basePath + '/', './');
-    var instrumenterLiteral = jsPath.match(/\.coffee$/) ? 'ibrik' : 'istanbul';
+    // default instrumenters
+    var instrumenterLiteral = 'istanbul';
 
     for (var pattern in instrumenterOverrides) {
       if (minimatch(file.originalPath, pattern, {dot: true})) {
@@ -49,9 +49,10 @@ var createCoveragePreprocessor = function(logger, basePath, reporters, coverageR
       }
     }
 
-    var instrumenter = new instrumenters[instrumenterLiteral].Instrumenter(instrumentersOptions[instrumenterLiteral]);
+    var instrumenter = new instrumenters[instrumenterLiteral].Instrumenter(instrumentersOptions[instrumenterLiteral] || {});
 
     instrumenter.instrument(content, jsPath, function(err, instrumentedCode) {
+
       if (err) {
         log.error('%s\n  at %s', err.message, file.originalPath);
       }

--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -7,6 +7,10 @@ var createCoveragePreprocessor = function(logger, basePath, reporters, coverageR
   var log = logger.create('preprocessor.coverage');
   var instrumenterOverrides = (coverageReporter && coverageReporter.instrumenter) || {};
   var instrumenters = {istanbul: istanbul, ibrik: ibrik, ismailia: ismailia};
+  var instrumentersOptions = Object.keys(instrumenters).reduce(function getInstumenterOptions(memo, instrumenterName){
+    memo[instrumenterName] = (coverageReporter && coverageReporter.instrumenterOptions && coverageReporter.instrumenterOptions[instrumenterName]) || {};
+    return memo;
+  }, {});
 
   // if coverage reporter is not used, do not preprocess the files
   if (reporters.indexOf('coverage') === -1) {
@@ -45,7 +49,7 @@ var createCoveragePreprocessor = function(logger, basePath, reporters, coverageR
       }
     }
 
-    var instrumenter = new instrumenters[instrumenterLiteral].Instrumenter();
+    var instrumenter = new instrumenters[instrumenterLiteral].Instrumenter(instrumentersOptions[instrumenterLiteral]);
 
     instrumenter.instrument(content, jsPath, function(err, instrumentedCode) {
       if (err) {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "dateformat": "~1.0.6",
     "ibrik": "~1.1.1",
-    "ismailia": "~0.9.0",
+    "ismailia": "douglasduteil/ismailia#next",
     "istanbul": "~0.3.0",
     "minimatch": "~0.3.0"
   },

--- a/package.json
+++ b/package.json
@@ -20,12 +20,10 @@
   "author": "SATO taichi <ryushi@gmail.com>",
   "dependencies": {
     "dateformat": "~1.0.6",
-    "ibrik": "~1.1.1",
-    "ismailia": "douglasduteil/ismailia#next",
-    "istanbul": "~0.3.0",
     "minimatch": "~0.3.0"
   },
   "peerDependencies": {
+    "istanbul": "~0.3.0",
     "karma": ">=0.9"
   },
   "license": "MIT",


### PR DESCRIPTION
douglasduteil added some changes that improve options on the instrumenter.  Without his changes I cannot exclude spec files from the coverage report with a particular combination of babelify etc.  However, he is behind a couple commits and his version doesn't fail the build when coverage is below thresholds.